### PR TITLE
Add truncate time option

### DIFF
--- a/dicomsort.py
+++ b/dicomsort.py
@@ -65,7 +65,9 @@ class DICOMSorter(object):
                 '-t': 'test',
                 '--test': 'test',
                 '-u': 'unsafe',
-                '--unsafe': 'unsafe'
+                '--unsafe': 'unsafe',
+                '-r': 'truncateTime',
+                '--truncateTime': 'truncateTime'
                 }
 
         self.defaultOptions = {
@@ -77,7 +79,8 @@ class DICOMSorter(object):
                 'keepGoing': False,
                 'verbose': False,
                 'test': False,
-                'unsafe': False
+                'unsafe': False,
+                'truncateTime': False
                 }
 
         self.requiredOptions = [ 'sourceDir', 'targetPattern', ]
@@ -128,6 +131,9 @@ class DICOMSorter(object):
                 value = ""
             if value == "":
                 value = "Unknown%s" % key
+            if self.options['truncateTime']:
+              if key.endswith("Time") and str(value)[str(value).find('.')+1:] == '000000':
+                value = str(value)[:str(value).find('.')]
             if safe:
               replacements[key] = self.safeFileName(str(value))
             else:


### PR DESCRIPTION
It turns out, it is possible to have individual series/instances within the
same study to have time-related attributes that both include and not include the fraction.

E.g., "121500.000000" and "121500", which will lead to an undesired result if that
key is used for sorting.

This commit adds a flag that will check for the presence of 0 fraction, and will truncate
it when found for the values of all keys that end in *Time.