### PR TITLE
Fix format strings that end with a keyword.

### DIFF
--- a/dicomsort.py
+++ b/dicomsort.py
@@ -164,14 +164,16 @@ class DICOMSorter(object):
                 key = ""
                 while True:
                     c = p[i]
-                    i += 1
-                    if not c.isalpha() or i >= end:
-                        fmt += ")s"
-                        i -= 1
-                        break
-                    else:
+                    if c.isalpha():
                         fmt += c
                         key += c
+                    else:
+                        fmt += ")s"
+                        break
+                    i += 1
+                    if i >= end:
+                        fmt += ")s"
+                        break
                 keys.append(key)
             else:
                 fmt += c


### PR DESCRIPTION
For example, a format string like:

  sorted/%StudyInstanceUID/%SeriesInstanceUID/%SOPInstanceUID

that ends with a keyword did not parse correctly resulting in paths like this:

  sorted/1_2_840_1/1_2_840_2/978583_130/UnknownSOPInstanceUID

This leads to duplicate paths, in the example for every second image of Series.

This commit fixes this behaviour.