### PR TITLE
Add move feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ dicomsort [options...] sourceDir targetDir/<patterns>
     [-k,--keepGoing] - report but ignore duplicate target files
     [-v,--verbose] - print diagnostics while processing
     [-s,--symlink] - create a symlink to dicom files in sourceDir instead of copying them
+    [-m, --move] - move files to the target directory
     [-t,--test] - run the built in self test (requires internet)
     [-u,--unsafe] - do not replace unsafe characters with '_' in the path
     [--help] - print this message

--- a/dicomsort.py
+++ b/dicomsort.py
@@ -64,6 +64,8 @@ class DICOMSorter(object):
                 '--keepGoing': 'keepGoing',
                 '-s': 'symlink',
                 '--symlink': 'symlink',
+                '-m': 'move',
+                '--move': 'move',
                 '-t': 'test',
                 '--test': 'test',
                 '-u': 'unsafe',
@@ -81,6 +83,7 @@ class DICOMSorter(object):
                 'keepGoing': False,
                 'verbose': False,
                 'symlink': False,
+                'move': False,
                 'test': False,
                 'unsafe': False,
                 'truncateTime': False
@@ -262,6 +265,10 @@ class DICOMSorter(object):
                 os.symlink(file, path)
                 if self.options['verbose']:
                     print("Symlinked %s, to %s" % (file,path))
+            elif self.options['move']:
+                shutil.move(file,path)
+                if self.options['verbose']:
+                    print("Moved %s, to %s" % (file,path))
             else:
                 shutil.copyfile(file,path)
                 if self.options['verbose']:
@@ -366,6 +373,7 @@ dicomsort [options...] sourceDir targetDir/<patterns>
     [-k,--keepGoing] - report but ignore duplicate target files
     [-v,--verbose] - print diagnostics while processing
     [-s,--symlink] - create a symlink to dicom files in sourceDir instead of copying them
+    [-m, --move] - move files to the target directory
     [-t,--test] - run the built in self test (requires internet)
     [-u,--unsafe] - do not replace unsafe characters with '_' in the path
     [--help] - print this message


### PR DESCRIPTION
This merge request introduces a move option (-m or --move) used for cleaning DICOM file structures. The move option allows users to directly move files instead of copying them, saving disk space during the cleaning process.

This feature is particularly beneficial when dealing with large DICOM datasets or limited disk space. By enabling the move option, files are moved on-the-fly, eliminating the need for temporary storage before removal.